### PR TITLE
Bump `curv-kzen` to `0.10.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["paillier", "homomorphic", "encryption", "zero-knowledge", "cryptoag
 [dependencies]
 rayon = "1.1"
 serde = { version = "1.0", features = ["derive"] }
-curv-kzen = { version = "0.9", default-features = false }
+curv-kzen = { version = "0.10.0", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"


### PR DESCRIPTION
This crate currently depends on version `0.9` which was just yanked: https://crates.io/crates/curv-kzen/versions.